### PR TITLE
Exclude paragonIE random_compat from scoper.

### DIFF
--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -4,6 +4,14 @@ declare(strict_types=1);
 
 use Isolated\Symfony\Component\Finder\Finder;
 
+$filesWhitelist = [];
+$randomCompatLibPath = 'vendor/paragonie/random_compat/lib/';
+foreach(scandir($randomCompatLibPath) as $file) {
+    if (!in_array($file, ['.', '..'])) {
+        $filesWhitelist[] = $randomCompatLibPath . $file;
+    }
+}
+
 return [
     'prefix' => 'ThirtybeesOnpay',
     'finders' => [
@@ -15,6 +23,7 @@ return [
             'composer.json',
         ]),
     ],
+    'files-whitelist' => $filesWhitelist,
     'whitelist-global-constants' => false,
     'whitelist-global-classes' => false,
     'whitelist-global-functions' => false,


### PR DESCRIPTION
Exclude paragonIE random_compat from scoper, since this repo is registered in the global space, and results in errors if prefixed with a namespace